### PR TITLE
Rename jr_sql_refresh success callback parameter

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -63,7 +63,7 @@ declare const jr_get_table_max_id: (tableName: string, customHandler?: CustomErr
 declare const jr_set_table_background_color: (tableName: string, rowId: number | "*", columnName: string, color: string, customHandler?: CustomErrorHandler) => void;
 declare const jr_date_add: (date: Date, value: string, timeUnit: TimeUnit, customHandler?: CustomErrorHandler) => Date;
 declare const jr_date_diff: (date1: Date, date2: Date, timeUnit: TimeUnit, customHandler?: CustomErrorHandler) => number;
-declare const jr_sql_refresh: (id: ElementId | ElementId[], successCallback?: (id: ElementId, value: any) => void, errorCallback?: (id: ElementId, error: string) => void, sequential?: boolean) => void;
+declare const jr_sql_refresh: (id: ElementId | ElementId[], successCallback?: (id: ElementId, oldValue: any) => void, errorCallback?: (id: ElementId, error: string) => void, sequential?: boolean) => void;
 declare const jr_subtable_refresh: (subtableViewName: string, columnName?: string, rowId?: number | "*", successCallback?: (subtableViewName: string, columnName: string, rowId: number | "*") => void, errorCallback?: (subtableViewName: string, columnName: string, rowId: number | "*", error: string) => void, customHandler?: CustomErrorHandler) => void;
 declare const jr_message: (message: string, data?: Object, customHandler?: CustomErrorHandler) => void;
 declare const jr_get_message: (message: string, data?: Object, customHandler?: CustomErrorHandler) => string;


### PR DESCRIPTION
Per the documentation: https://portal.jobrouter.com/documentation/en/5.1/javascript_api/index.html?jr_sql_refresh.htm

> Parameter | Type | Description
> -- | -- | --
> successCallback |function | Optional: Specifies a [callback function (see examples)](https://portal.jobrouter.com/documentation/en/5.1/javascript_api/konzeptvoncallback-funktionen.htm) to be executed in case of success. The element name and the `old value` are passed to it as parameter.

The current variable name `value` is misleading. Changing this to `oldValue` should not be a breaking change and will allow IDE hinting to imply the correct use of what the callback function is receiving.