### PR TITLE
Define types with more detail

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -1,61 +1,96 @@
 /********************************************************
- JobRouter JavaScript-API Stubs v5.1
+ JobRouter JavaScript-API Stubs v2022.1
  ********************************************************/
 type CustomErrorHandler = (errorMessage: string) => void;
-type ElementId = string;
-type StepAction = "abort" | "answer" | "assign" | "back" | "finish" | "jumpTo" | "request" | "resubmission" | "save" | "send";
-type TimeUnit = "s" | "m" | "h" | "d";
-type Stamp = {
-    text: string
-    includeTime: boolean
-    includeDate: boolean
-    color: string
-    onStamp?: ((stamp: Stamp, x: number, y: number) => void)
+type DecimalSeparator = "" | "," | ".";
+type DialogFunctionUserParameters = {
+    [key: string]: unknown;
 };
+type DialogSuccessReturnObject = {
+    status: string;
+    result?: {
+        [key: string]: unknown;
+    };
+};
+type DialogErrorReturnObject = {
+    status: string;
+    message?: string;
+    result?: {
+        [key: string]: unknown;
+    };
+};
+type ElementValue = string | number | Date | boolean;
+type MessageData = {
+    [key: string]: ElementValue;
+};
+type StepAction = "abort" | "answer" | "assign" | "back" | "finish" | "jumpTo" | "request" | "resubmission" | "save" | "send";
+type Stamp = {
+    text: string;
+    includeTime: boolean;
+    includeDate: boolean;
+    color: string;
+    onStamp?: (stamp: Stamp, x: number, y: number) => void;
+};
+type StampOptions = {
+    includeTime: boolean;
+    includeDate: boolean;
+    color: string;
+    onStamp?: (stamp: Stamp, x: number, y: number) => void;
+};
+type SubtableData = {
+    [key: number]: {
+        [key: string]: ElementValue;
+    };
+};
+type SubtableRowObject = {
+    [key: string]: ElementValue;
+};
+type ThousandsSeparator = "" | "," | "." | "'";
+type TimeUnit = "s" | "m" | "h" | "d";
 
 declare const jr_execute: (action: StepAction | "reserve") => void;
-declare const jr_get_value: (id: ElementId, customErrorHandler?: CustomErrorHandler) => any;
-declare const jr_set_value: (id: ElementId, value: any, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_display_value: (id: ElementId, customHandler?: CustomErrorHandler) => any;
-declare const jr_reset_value: (id: ElementId, customHandler?: CustomErrorHandler) => void;
-declare const jr_set_required: (id: ElementId, value?: boolean, customHandler?: CustomErrorHandler) => void;
-declare const jr_is_required: (id: ElementId, customHandler?: CustomErrorHandler) => boolean;
-declare const jr_set_label: (id: ElementId, label: string, radioValue?: string, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_label: (id: ElementId, radioValue?: string, customHandler?: CustomErrorHandler) => string;
-declare const jr_set_label2: (id: ElementId, label: string, radioValue?: string, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_label2: (id: ElementId, radioValue?: string, customHandler?: CustomErrorHandler) => string;
-declare const jr_show: (obj: string | string[]) => void;
-declare const jr_hide: (obj: string | string[]) => void;
-declare const jr_is_visible: (id: ElementId, customHandler?: CustomErrorHandler) => boolean;
+declare const jr_get_value: (id: string, customErrorHandler?: CustomErrorHandler) => ElementValue;
+declare const jr_set_value: (id: string, value: ElementValue, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_display_value: (id: string, customHandler?: CustomErrorHandler) => ElementValue;
+declare const jr_reset_value: (id: string, customHandler?: CustomErrorHandler) => void;
+declare const jr_set_required: (id: string, value?: boolean, customHandler?: CustomErrorHandler) => void;
+declare const jr_is_required: (id: string, customHandler?: CustomErrorHandler) => boolean;
+declare const jr_set_label: (id: string, label: string, radioValue?: string, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_label: (id: string, radioValue?: string, customHandler?: CustomErrorHandler) => string;
+declare const jr_set_label2: (id: string, label: string, radioValue?: string, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_label2: (id: string, radioValue?: string, customHandler?: CustomErrorHandler) => string;
+declare const jr_show: (id: string | string[]) => void;
+declare const jr_hide: (id: string | string[]) => void;
+declare const jr_is_visible: (id: string, customHandler?: CustomErrorHandler) => boolean;
 declare const jr_show_page: (pageName: string | string[]) => void;
 declare const jr_hide_page: (pageName: string | string[]) => void;
 declare const jr_show_step_action: (action: StepAction | StepAction[]) => void;
 declare const jr_hide_step_action: (action: StepAction | StepAction[]) => void;
 declare const jr_set_step_action_label: (action: StepAction, label: string) => void;
 declare const jr_select_page: (pageName: string) => void;
-declare const jr_set_readonly: (id: ElementId, value?: boolean, customHandler?: CustomErrorHandler) => void;
-declare const jr_is_readonly: (id: ElementId, customHandler?: CustomErrorHandler) => boolean;
-declare const jr_set_disabled: (id: ElementId, value?: boolean, customHandler?: CustomErrorHandler) => void;
-declare const jr_is_disabled: (id: ElementId, customHandler?: CustomErrorHandler) => boolean;
-declare const jr_set_background_color: (id: ElementId, color: string, customHandler?: CustomErrorHandler) => void;
-declare const jr_set_subtable_value: (subtableViewName: string, rowId: number, columnName: string, value: any, customHandler?: CustomErrorHandler) => void;
-declare const jr_set_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, value: any, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_subtable_value: (subtableViewName: string, rowId: number | "sum", columnName: string, customHandler?: CustomErrorHandler) => any;
-declare const jr_get_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, customHandler?: CustomErrorHandler) => any;
-declare const jr_add_subtable_row: (subtableViewName: string, numberOfRows: number | Object | Object[], ignoreMaxRows?: boolean, finishCallback?: (addedRows: number) => void, customHandler?: CustomErrorHandler) => void;
+declare const jr_set_readonly: (id: string, value?: boolean, customHandler?: CustomErrorHandler) => void;
+declare const jr_is_readonly: (id: string, customHandler?: CustomErrorHandler) => boolean;
+declare const jr_set_disabled: (id: string, value?: boolean, customHandler?: CustomErrorHandler) => void;
+declare const jr_is_disabled: (id: string, customHandler?: CustomErrorHandler) => boolean;
+declare const jr_set_background_color: (id: string, color: string, customHandler?: CustomErrorHandler) => void;
+declare const jr_set_subtable_value: (subtableViewName: string, rowId: number, columnName: string, value: ElementValue, customHandler?: CustomErrorHandler) => void;
+declare const jr_set_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, value: ElementValue, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_subtable_value: (subtableViewName: string, rowId: number | "sum", columnName: string, customHandler?: CustomErrorHandler) => ElementValue;
+declare const jr_get_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, customHandler?: CustomErrorHandler) => ElementValue;
+declare const jr_add_subtable_row: (subtableViewName: string, numberOfRows: number | SubtableRowObject | SubtableRowObject[], ignoreMaxRows?: boolean, finishCallback?: (addedRows: number) => void, customHandler?: CustomErrorHandler) => void;
 declare const jr_remove_subtable_row: (subtableViewName: string, rowId: number | number[], ignoreMinRows?: boolean) => void;
 declare const jr_copy_subtable_row: (subtableViewName: string, rowId: number | number[]) => void;
-declare const jr_hide_subtable_column: (subtableViewName: string, columnId: string | string[], radioValue?: string) => void;
-declare const jr_show_subtable_column: (subtableViewName: string, columnId: string | string[], radioValue?: string) => void;
+declare const jr_hide_subtable_column: (subtableViewName: string, columnName: string | string[], radioValue?: string) => void;
+declare const jr_show_subtable_column: (subtableViewName: string, columnName: string | string[], radioValue?: string) => void;
 declare const jr_hide_subtable_row: (subtableViewName: string, rowId: number) => void;
 declare const jr_show_subtable_row: (subtableViewName: string, rowId: number) => void;
 declare const jr_get_subtable_count: (subtableViewName: string, customHandler?: CustomErrorHandler) => number;
 declare const jr_get_subtable_max_id: (subtableViewName: string, customHandler?: CustomErrorHandler) => number;
 declare const jr_get_subtable_row_ids: (subtableViewName: string, customHandler?: CustomErrorHandler) => number[];
-declare const jr_sum_subtable_column: (subtableViewName: string, columnName: string, thousandsSeparator?: string, decimalSeparator?: string, decimalPlace?: number) => number;
-declare const jr_loop_table: (subtableViewName: string, callback: (subtableView: string, currentRow: number) => void, customHandler?: CustomErrorHandler) => void;
-declare const jr_set_column_label: (elementName: string, columnName: string, label: string, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_column_label: (elementName: string, columnName: string, customHandler?: CustomErrorHandler) => string;
+declare const jr_sum_subtable_column: (subtableViewName: string, columnName: string, thousandsSeparator?: ThousandsSeparator, decimalSeparator?: DecimalSeparator, decimalPlace?: number) => number;
+declare const jr_loop_table: (subtableViewName: string, callback: (subtableViewName: string, currentRow: number) => void, customHandler?: CustomErrorHandler) => void;
+declare const jr_set_column_label: (id: string, columnName: string, label: string, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_column_label: (id: string, columnName: string, customHandler?: CustomErrorHandler) => string;
 declare const jr_set_cell_label2: (subtableViewName: string, rowId: number, columnName: string, label: string, radioValue?: string, customHandler?: CustomErrorHandler) => void;
 declare const jr_get_cell_label2: (subtableViewName: string, rowId: number, columnName: string, radioValue?: string, customHandler?: CustomErrorHandler) => string;
 declare const jr_get_table_count: (tableName: string, customHandler?: CustomErrorHandler) => number;
@@ -63,18 +98,18 @@ declare const jr_get_table_max_id: (tableName: string, customHandler?: CustomErr
 declare const jr_set_table_background_color: (tableName: string, rowId: number | "*", columnName: string, color: string, customHandler?: CustomErrorHandler) => void;
 declare const jr_date_add: (date: Date, value: string, timeUnit: TimeUnit, customHandler?: CustomErrorHandler) => Date;
 declare const jr_date_diff: (date1: Date, date2: Date, timeUnit: TimeUnit, customHandler?: CustomErrorHandler) => number;
-declare const jr_sql_refresh: (id: ElementId | ElementId[], successCallback?: (id: ElementId, oldValue: any) => void, errorCallback?: (id: ElementId, error: string) => void, sequential?: boolean) => void;
+declare const jr_sql_refresh: (id: string | string[], successCallback?: (id: string, oldValue: ElementValue) => void, errorCallback?: (id: string, error: string) => void, sequential?: boolean) => void;
 declare const jr_subtable_refresh: (subtableViewName: string, columnName?: string, rowId?: number | "*", successCallback?: (subtableViewName: string, columnName: string, rowId: number | "*") => void, errorCallback?: (subtableViewName: string, columnName: string, rowId: number | "*", error: string) => void, customHandler?: CustomErrorHandler) => void;
-declare const jr_message: (message: string, data?: Object, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_message: (message: string, data?: Object, customHandler?: CustomErrorHandler) => string;
+declare const jr_message: (message: string, data?: MessageData, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_message: (message: string, data?: MessageData, customHandler?: CustomErrorHandler) => string;
 declare const jr_allow_send: (value: boolean) => void;
 declare const jr_enable_send: () => void;
 declare const jr_disable_send: () => void;
 declare const jr_set_steplabel: (label: string) => void;
 declare const jr_get_steplabel: () => string;
 declare const jr_print: (callback?: () => void) => void;
-declare const jr_get_table_value: (tableName: string, rowId: number, columnName: string, customHandler?: CustomErrorHandler) => any;
-declare const jr_execute_dialog_function: (functionName: string, userParameters?: Object, onSuccessCallback?: (returnObject: { status: string, result?: Object }) => void, onErrorCallback?: (returnObject: { status: string, message?: string, result?: Object }) => void) => void;
+declare const jr_get_table_value: (tableName: string, rowId: number, columnName: string, customHandler?: CustomErrorHandler) => ElementValue;
+declare const jr_execute_dialog_function: (functionName: string, userParameters?: DialogFunctionUserParameters, onSuccessCallback?: (returnObject: DialogSuccessReturnObject) => void, onErrorCallback?: (returnObject: DialogErrorReturnObject) => void) => void;
 declare const jr_set_dialog_unchanged: () => void;
 declare const jr_has_dialog_changed: () => boolean;
 declare const jr_enable_dialog_changecheck: () => void;
@@ -86,10 +121,10 @@ declare const jr_notify_info: (message: string, timeoutInSeconds?: number) => vo
 declare const jr_notify_warn: (message: string, timeoutInSeconds?: number) => void;
 declare const jr_notify_error: (message: string, timeoutInSeconds?: number) => void;
 declare const jr_set_window_title: (title: string) => void;
-declare const jr_viewer_stamp_create: (stampText: string, options: Object) => Stamp;
+declare const jr_viewer_stamp_create: (stampText: string, options: StampOptions) => Stamp;
 declare const jr_viewer_stamp_activate: (stamp: Stamp) => void;
 declare const jr_viewer_stamp_remove: (stamp: Stamp) => void;
-declare const jr_subtable_init: (subtableViewName: string, subtableData: Object, successCallback?: (subtableViewName: string) => void, errorCallback?: (subtableViewName: string, error: string) => void) => void;
+declare const jr_subtable_init: (subtableViewName: string, subtableData: SubtableData, successCallback?: (subtableViewName: string) => void, errorCallback?: (subtableViewName: string, error: string) => void) => void;
 declare const jr_get_instance_id: () => number;
 declare const jr_close_section: (sectionName: string) => void;
 declare const jr_open_section: (sectionName: string) => void;

--- a/api.d.ts
+++ b/api.d.ts
@@ -20,27 +20,20 @@ type DialogErrorReturnObject = {
     };
 };
 type ElementValue = string | number | Date | boolean;
-type MessageData = {
-    [key: string]: ElementValue;
+type MessageReplacements = {
+    [key: string]: string;
 };
 type StepAction = "abort" | "answer" | "assign" | "back" | "finish" | "jumpTo" | "request" | "resubmission" | "save" | "send";
-type Stamp = {
-    text: string;
-    includeTime: boolean;
-    includeDate: boolean;
-    color: string;
-    onStamp?: (stamp: Stamp, x: number, y: number) => void;
-};
+type Stamp = { text: string } & StampOptions;
+type StampOptionOnStampFunction = (stamp: Stamp, x: number, y: number) => void;
 type StampOptions = {
     includeTime: boolean;
     includeDate: boolean;
     color: string;
-    onStamp?: (stamp: Stamp, x: number, y: number) => void;
+    onStamp?: StampOptionOnStampFunction;
 };
 type SubtableData = {
-    [key: number]: {
-        [key: string]: ElementValue;
-    };
+    [key: number]: SubtableRowObject;
 };
 type SubtableRowObject = {
     [key: string]: ElementValue;
@@ -77,7 +70,7 @@ declare const jr_set_subtable_value: (subtableViewName: string, rowId: number, c
 declare const jr_set_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, value: ElementValue, customHandler?: CustomErrorHandler) => void;
 declare const jr_get_subtable_value: (subtableViewName: string, rowId: number | "sum", columnName: string, customHandler?: CustomErrorHandler) => ElementValue;
 declare const jr_get_subtable_display_value: (subtableViewName: string, rowId: number, columnName: string, customHandler?: CustomErrorHandler) => ElementValue;
-declare const jr_add_subtable_row: (subtableViewName: string, numberOfRows: number | SubtableRowObject | SubtableRowObject[], ignoreMaxRows?: boolean, finishCallback?: (addedRows: number) => void, customHandler?: CustomErrorHandler) => void;
+declare const jr_add_subtable_row: (subtableViewName: string, rows: number | SubtableRowObject | SubtableRowObject[], ignoreMaxRows?: boolean, finishCallback?: (addedRows: number) => void, customHandler?: CustomErrorHandler) => void;
 declare const jr_remove_subtable_row: (subtableViewName: string, rowId: number | number[], ignoreMinRows?: boolean) => void;
 declare const jr_copy_subtable_row: (subtableViewName: string, rowId: number | number[]) => void;
 declare const jr_hide_subtable_column: (subtableViewName: string, columnName: string | string[], radioValue?: string) => void;
@@ -100,8 +93,8 @@ declare const jr_date_add: (date: Date, value: string, timeUnit: TimeUnit, custo
 declare const jr_date_diff: (date1: Date, date2: Date, timeUnit: TimeUnit, customHandler?: CustomErrorHandler) => number;
 declare const jr_sql_refresh: (id: string | string[], successCallback?: (id: string, oldValue: ElementValue) => void, errorCallback?: (id: string, error: string) => void, sequential?: boolean) => void;
 declare const jr_subtable_refresh: (subtableViewName: string, columnName?: string, rowId?: number | "*", successCallback?: (subtableViewName: string, columnName: string, rowId: number | "*") => void, errorCallback?: (subtableViewName: string, columnName: string, rowId: number | "*", error: string) => void, customHandler?: CustomErrorHandler) => void;
-declare const jr_message: (message: string, data?: MessageData, customHandler?: CustomErrorHandler) => void;
-declare const jr_get_message: (message: string, data?: MessageData, customHandler?: CustomErrorHandler) => string;
+declare const jr_message: (message: string, replacements?: MessageReplacements, customHandler?: CustomErrorHandler) => void;
+declare const jr_get_message: (message: string, replacements?: MessageReplacements, customHandler?: CustomErrorHandler) => string;
 declare const jr_allow_send: (value: boolean) => void;
 declare const jr_enable_send: () => void;
 declare const jr_disable_send: () => void;


### PR DESCRIPTION
- For things like `DecimalSeparator` and others I reviewed `jobrouter.js` and found the values that are accepted
- Avoid using `any`, instead define specific expected types
- Avoid using generic `Object`, instead define specific objects as much as possible
  - Some object properties have an `unknown` type (although if more context is available as to what is actually returned it would be ideal to define these more specifically)
- Don't define aliases for common types (ex: `type ElementId = string;`)
- Be consistent with parameter naming
  - `columnId` changed to `columnName` for consistency
  - `jr_show: (obj: string | string[]) => void;` changed to `jr_show: (id: string | string[]) => void;` because `obj` implies we should be passing in an object

A potential future option would be to add `dependencies` to `package.json` for `@types/jquery` and rely on and extend the underlying types as needed, which would be more accurate in cases where `$(...).val();` is returned from a `jr_...` function. This is more of a side-note for discussion.